### PR TITLE
Fix pre-release logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ From now on, the auto updater will ask your Hazel deployment for updates!
 The following environment variables can be used optionally:
 
 - `INTERVAL`: Refreshes the cache every x minutes ([restrictions](https://developer.github.com/changes/2012-10-14-rate-limit-changes/)) (defaults to 15 minutes)
-- `PRE`: When defined with a value of `1`, only pre-releases will be cached
+- `PRE`: When defined with a value of `1`, pre-releases will be cached as well as production releases
 - `TOKEN`: Your GitHub token (for private repos)
 - `URL`: The server's URL (for private repos - when running on [Vercel](https://vercel.com), this field is filled with the URL of the deployment automatically)
 

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -102,8 +102,18 @@ module.exports = class Cache {
     }
 
     const release = data.find(item => {
-      const isPre = Boolean(pre) === Boolean(item.prerelease)
-      return !item.draft && isPre
+      // We don't want to include drafts
+      if (item.draft) {
+        return false
+      }
+
+      // Only include pre-releases if the `pre` env variable is true
+      const includePrerelease = Boolean(pre)
+      if (!includePrerelease && Boolean(item.prerelease)) {
+        return false
+      }
+
+      return true
     })
 
     if (!release || !release.assets || !Array.isArray(release.assets)) {


### PR DESCRIPTION
Currently, the PRE flag *only* shows pre-releases so if the newest release isn't a pre-release, preview servers will show the wrong release.

This fixes that by returning either a pre-release *or* a regular relase if the PRE flag is set.